### PR TITLE
remove unnecessarily system auth delegator role

### DIFF
--- a/test-scripts/resources/roles.yaml
+++ b/test-scripts/resources/roles.yaml
@@ -2,23 +2,6 @@ apiVersion: v1
 kind: List
 items:
 - apiVersion: v1
-  kind: ClusterRole
-  metadata:
-    name: system:auth-delegator
-  rules:
-  - apiGroups:
-    - authentication.k8s.io
-    resources:
-    - tokenreviews
-    verbs:
-    - create
-  - apiGroups:
-    - authorization.k8s.io
-    resources:
-    - subjectaccessreviews
-    verbs:
-    - create
-- apiVersion: v1
   kind: Role
   metadata:
     name: extension-apiserver-authentication-reader
@@ -79,4 +62,4 @@ items:
   - system:unauthenticated
   - system:authenticated
   - system:anonymous
-  
+


### PR DESCRIPTION
this role is automatically created by openshift now.
