### PR TITLE
fix fork-rename.sh OSX

### DIFF
--- a/hack/fork-rename.sh
+++ b/hack/fork-rename.sh
@@ -5,7 +5,11 @@ if [[ -z $1 || -z $2 ]]; then
   exit 1
 fi
 
-find . -type f -name *.go -exec sed -i "s#github.com/openshift/open-service-broker-sdk#github.com/$1/$2#g" {} +
-
-sed -i "s#github.com/openshift/open-service-broker-sdk#github.com/$1/$2#g" Makefile
-
+OS_TARGET=`uname -s`  
+BACKUP=""
+if  [ "$OS_TARGET" == "Darwin" ]; then
+  BACKUP="''"
+fi
+  
+find . -type f -name *.go -exec sed -i $BACKUP  "s#github.com/openshift/open-service-broker-sdk#github.com/$1/$2#g" {} +
+  sed -i $BACKUP  "s#github.com/openshift/open-service-broker-sdk#github.com/$1/$2#g" Makefile

--- a/hack/fork-rename.sh
+++ b/hack/fork-rename.sh
@@ -6,10 +6,13 @@ if [[ -z $1 || -z $2 ]]; then
 fi
 
 OS_TARGET=`uname -s`  
-BACKUP=""
+REPLACE="s#github.com/openshift/open-service-broker-sdk#github.com/$1/$2#g"
+
 if  [ "$OS_TARGET" == "Darwin" ]; then
-  BACKUP="''"
+  find . -type f -name *.go -exec sed -i '' "${REPLACE}" {} +
+  sed -i ''  "${REPLACE}" Makefile
+  exit
 fi
   
-find . -type f -name *.go -exec sed -i $BACKUP  "s#github.com/openshift/open-service-broker-sdk#github.com/$1/$2#g" {} +
-  sed -i $BACKUP  "s#github.com/openshift/open-service-broker-sdk#github.com/$1/$2#g" Makefile
+find . -type f -name *.go -exec sed -i "${REPLACE}" {} +
+sed -i  "${REPLACE}" Makefile


### PR DESCRIPTION
The script did not work as expected on OSX Due to differences in the sed command.