### PR TITLE
Operation unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - sudo apt-get install realpath -y
 
 script:
-  - make build verify
+  - make build test verify
 
 matrix:
   allow_failures:

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ test: build test-unit
 
 test-unit: build
 	@echo Running tests:
-	go test $(UNIT_TEST_FLAGS) \
+	go test -cover $(UNIT_TEST_FLAGS) \
 	  $(addprefix $(BROKER_PKG)/,$(TEST_DIRS))
 
 clean: clean-bin

--- a/pkg/openservicebroker/operations/bind.go
+++ b/pkg/openservicebroker/operations/bind.go
@@ -12,14 +12,14 @@ import (
 
 // Bind handles bind requests from the service catalog by returning
 // a bind response with credentials for the service instance.
-func (b *BrokerOperations) Bind(instance_id, binding_id string, breq *openservicebroker.BindRequest) *openservicebroker.Response {
+func (b *BrokerOperations) Bind(instanceID, bindingID string, breq *openservicebroker.BindRequest) *openservicebroker.Response {
 	// Find the service instance that is being bound to
-	si, err := b.Client.ServiceInstances(broker.Namespace).Get(instance_id, metav1.GetOptions{})
+	si, err := b.Client.Broker().ServiceInstances(broker.Namespace).Get(instanceID, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return &openservicebroker.Response{http.StatusGone, &openservicebroker.BindResponse{}, nil}
+			return &openservicebroker.Response{Code: http.StatusGone, Body: &openservicebroker.BindResponse{}, Err: nil}
 		}
-		return &openservicebroker.Response{http.StatusInternalServerError, nil, err}
+		return &openservicebroker.Response{Code: http.StatusInternalServerError, Body: nil, Err: err}
 	}
 
 	// in principle, bind should alter state somewhere

--- a/pkg/openservicebroker/operations/bind_test.go
+++ b/pkg/openservicebroker/operations/bind_test.go
@@ -1,0 +1,90 @@
+package operations
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	brokerapi "github.com/openshift/open-service-broker-sdk/pkg/apis/broker"
+	clientset "github.com/openshift/open-service-broker-sdk/pkg/client/clientset_generated/internalclientset/fake"
+	"github.com/openshift/open-service-broker-sdk/pkg/openservicebroker"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestBind(t *testing.T) {
+	cases := []struct {
+		Name        string
+		ExpectError bool
+		Code        int
+		GetError    error
+		InstanceID  string
+		BindingID   string
+		BindingReq  *openservicebroker.BindRequest
+	}{
+		{
+			Name:        "binds ok",
+			ExpectError: false,
+			Code:        http.StatusCreated,
+			GetError:    nil,
+			InstanceID:  "instid",
+			BindingID:   "bindingid",
+			BindingReq:  &openservicebroker.BindRequest{},
+		},
+		{
+			Name:        "binds fails on error",
+			ExpectError: true,
+			Code:        http.StatusInternalServerError,
+			GetError:    errors.New("something is terribly wrong"),
+			InstanceID:  "instid",
+			BindingID:   "bindingid",
+			BindingReq:  &openservicebroker.BindRequest{},
+		},
+		{
+			Name:        "binds fails on service instance not found",
+			ExpectError: false,
+			Code:        http.StatusGone,
+			GetError:    kerrors.NewNotFound(brokerapi.Resource("serviceInstance"), "test"),
+			InstanceID:  "instid",
+			BindingID:   "bindingid",
+			BindingReq:  &openservicebroker.BindRequest{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			client := &clientset.Clientset{}
+			client.Fake = ktesting.Fake{}
+			client.Fake.AddReactor("get", "*", func(a ktesting.Action) (bool, runtime.Object, error) {
+				serviceInstance := &brokerapi.ServiceInstance{
+					Spec: brokerapi.ServiceInstanceSpec{
+						Credential: "supersecret",
+					},
+				}
+				return true, serviceInstance, tc.GetError
+			})
+			broker := &BrokerOperations{
+				Client: client,
+			}
+			res := broker.Bind(tc.InstanceID, tc.BindingID, tc.BindingReq)
+			if tc.ExpectError && res.Err == nil {
+				t.Fatal("Expected an err binding but got none")
+			}
+			if !tc.ExpectError && res.Err != nil {
+				t.Fatalf("did not expect an error binding : %s ", res.Err)
+			}
+			if tc.Code != res.Code {
+				t.Fatalf("expected a response code %v but got %v ", tc.Code, res.Code)
+			}
+			if res.Code == http.StatusCreated {
+				bindRes, ok := res.Body.(*openservicebroker.BindResponse)
+				if !ok {
+					t.Fatal("expected the response body to be a BindResponse")
+				}
+				if _, ok := bindRes.Credentials["credential"]; !ok {
+					t.Fatal("expected to find a credential key in the BindResponse")
+				}
+			}
+		})
+	}
+}

--- a/pkg/openservicebroker/operations/broker.go
+++ b/pkg/openservicebroker/operations/broker.go
@@ -9,5 +9,5 @@ import (
 // It users a resource client to access the ServiceInstance resources
 // that are used to store instance/binding state information.
 type BrokerOperations struct {
-	Client *clientset.Clientset
+	Client clientset.Interface
 }

--- a/pkg/openservicebroker/operations/catalog.go
+++ b/pkg/openservicebroker/operations/catalog.go
@@ -12,11 +12,11 @@ func (b *BrokerOperations) Catalog() *openservicebroker.Response {
 
 	services := make([]*openservicebroker.Service, 1)
 
-	service_metadata := make(map[string]interface{})
-	service_metadata["metadata_key1"] = "metadata_value1"
+	serviceMetadata := make(map[string]interface{})
+	serviceMetadata["metadata_key1"] = "metadata_value1"
 
-	service_plans := make([]openservicebroker.Plan, 1)
-	service_plans[0] = openservicebroker.Plan{
+	servicePlans := make([]openservicebroker.Plan, 1)
+	servicePlans[0] = openservicebroker.Plan{
 		Name:        "gold-plan",
 		ID:          "gold-plan-id",
 		Description: "gold plan description",
@@ -29,8 +29,8 @@ func (b *BrokerOperations) Catalog() *openservicebroker.Response {
 		Description: "service description",
 		Tags:        []string{"tag1", "tag2"},
 		Bindable:    true,
-		Metadata:    service_metadata,
-		Plans:       service_plans,
+		Metadata:    serviceMetadata,
+		Plans:       servicePlans,
 	}
-	return &openservicebroker.Response{http.StatusOK, &openservicebroker.CatalogResponse{Services: services}, nil}
+	return &openservicebroker.Response{Code: http.StatusOK, Body: &openservicebroker.CatalogResponse{Services: services}, Err: nil}
 }

--- a/pkg/openservicebroker/operations/catalog_test.go
+++ b/pkg/openservicebroker/operations/catalog_test.go
@@ -1,0 +1,48 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/openshift/open-service-broker-sdk/pkg/openservicebroker"
+)
+
+func TestCatalog(t *testing.T) {
+	cases := []struct {
+		Name         string
+		ExpectError  bool
+		Code         int
+		CatalogItems int
+	}{
+		{
+			Name:         "test get catalog",
+			ExpectError:  false,
+			Code:         200,
+			CatalogItems: 1,
+		},
+	}
+
+	broker := &BrokerOperations{}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			res := broker.Catalog()
+			if tc.ExpectError && res.Err == nil {
+				t.Fatal("expected an err getting the catalog but got none")
+			}
+			if !tc.ExpectError && res.Err != nil {
+				t.Fatalf("did not expect an error getting the catalog : %s ", res.Err)
+			}
+			if nil != res.Body {
+				catRes, ok := res.Body.(*openservicebroker.CatalogResponse)
+				if !ok {
+					t.Fatalf("casting res.Body to a slice of services failed")
+				}
+				if len(catRes.Services) != tc.CatalogItems {
+					t.Fatalf("expected %d catalog items but instead got %d ", tc.CatalogItems, len(catRes.Services))
+				}
+			}
+			if res.Code != tc.Code {
+				t.Fatalf("expected response code %d but got %d ", tc.Code, res.Code)
+			}
+		})
+	}
+}

--- a/pkg/openservicebroker/operations/deprovision.go
+++ b/pkg/openservicebroker/operations/deprovision.go
@@ -14,13 +14,13 @@ import (
 // It deletes the ServiceInstance associatied with the instanceid being deprovisioned.
 // This will trigger the controller to see the service instance as deleted and
 // further cleanup can be done there.
-func (b *BrokerOperations) Deprovision(instance_id string) *openservicebroker.Response {
-	err := b.Client.ServiceInstances(broker.Namespace).Delete(instance_id, &metav1.DeleteOptions{})
+func (b *BrokerOperations) Deprovision(instanceID string) *openservicebroker.Response {
+	err := b.Client.Broker().ServiceInstances(broker.Namespace).Delete(instanceID, &metav1.DeleteOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return &openservicebroker.Response{http.StatusGone, &openservicebroker.DeprovisionResponse{}, nil}
+			return &openservicebroker.Response{Code: http.StatusGone, Body: &openservicebroker.DeprovisionResponse{}, Err: nil}
 		}
-		return &openservicebroker.Response{http.StatusInternalServerError, nil, err}
+		return &openservicebroker.Response{Code: http.StatusInternalServerError, Body: nil, Err: err}
 	}
-	return &openservicebroker.Response{http.StatusAccepted, &openservicebroker.DeprovisionResponse{Operation: openservicebroker.OperationDeprovisioning}, nil}
+	return &openservicebroker.Response{Code: http.StatusAccepted, Body: &openservicebroker.DeprovisionResponse{Operation: openservicebroker.OperationDeprovisioning}, Err: nil}
 }

--- a/pkg/openservicebroker/operations/deprovision_test.go
+++ b/pkg/openservicebroker/operations/deprovision_test.go
@@ -1,0 +1,68 @@
+package operations
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/openshift/open-service-broker-sdk/pkg/apis/broker"
+	clientset "github.com/openshift/open-service-broker-sdk/pkg/client/clientset_generated/internalclientset/fake"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestDeprovision(t *testing.T) {
+	cases := []struct {
+		Name        string
+		InstanceID  string
+		ExpectError bool
+		DeleteError error
+		Code        int
+	}{
+		{
+			Name:        "deprovisions ok",
+			InstanceID:  "test",
+			ExpectError: false,
+			Code:        http.StatusAccepted,
+		},
+		{
+			Name:        "deprovisions fails with unexpected error",
+			InstanceID:  "test",
+			ExpectError: true,
+			DeleteError: errors.New("unexpected error deprovisioning"),
+			Code:        http.StatusInternalServerError,
+		},
+		{
+			Name:        "deprovisions fails with not found error",
+			InstanceID:  "test",
+			ExpectError: false,
+			DeleteError: kerrors.NewNotFound(broker.Resource("serviceInstance"), "test"),
+			Code:        http.StatusGone,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			client := &clientset.Clientset{}
+			client.Fake = ktesting.Fake{}
+			client.Fake.AddReactor("delete", "*", func(a ktesting.Action) (bool, runtime.Object, error) {
+				return true, nil, tc.DeleteError
+			})
+			broker := &BrokerOperations{
+				Client: client,
+			}
+			res := broker.Deprovision(tc.InstanceID)
+			if tc.ExpectError && res.Err == nil {
+				t.Fatal("Expected an err deprovisioning but got none")
+			}
+			if !tc.ExpectError && res.Err != nil {
+				t.Fatalf("did not expect an error deprovisioning : %s ", res.Err)
+			}
+			if tc.Code != res.Code {
+				t.Fatalf("expected a response code %v but got %v ", tc.Code, res.Code)
+			}
+
+		})
+	}
+}

--- a/pkg/openservicebroker/operations/lastoperation_test.go
+++ b/pkg/openservicebroker/operations/lastoperation_test.go
@@ -1,0 +1,131 @@
+package operations
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/openshift/open-service-broker-sdk/pkg/apis/broker"
+	clientset "github.com/openshift/open-service-broker-sdk/pkg/client/clientset_generated/internalclientset/fake"
+	"github.com/openshift/open-service-broker-sdk/pkg/openservicebroker"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	kapi "k8s.io/client-go/pkg/api"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestLastoperation(t *testing.T) {
+	cases := []struct {
+		Name                string
+		ExpectError         bool
+		Operation           openservicebroker.Operation
+		ServiceInstanceCond []broker.ServiceInstanceCondition
+		Code                int
+		GetError            error
+		InstanceID          string
+		ExpectedState       openservicebroker.LastOperationState
+	}{
+		{
+			Name:        "lastoperation provision ok",
+			ExpectError: false,
+			Code:        http.StatusOK,
+			Operation:   openservicebroker.OperationProvisioning,
+			ServiceInstanceCond: []broker.ServiceInstanceCondition{{
+				Type:   broker.ServiceInstanceReady,
+				Status: kapi.ConditionTrue,
+			}},
+			GetError:      nil,
+			InstanceID:    "instance",
+			ExpectedState: openservicebroker.LastOperationStateSucceeded,
+		},
+		{
+			Name:        "lastoperation provision failed",
+			ExpectError: false,
+			Code:        http.StatusOK,
+			Operation:   openservicebroker.OperationProvisioning,
+			ServiceInstanceCond: []broker.ServiceInstanceCondition{{
+				Type:   broker.ServiceInstanceFailed,
+				Status: kapi.ConditionTrue,
+			}},
+			GetError:      nil,
+			InstanceID:    "instance",
+			ExpectedState: openservicebroker.LastOperationStateFailed,
+		},
+		{
+			Name:        "lastoperation provision in progress",
+			ExpectError: false,
+			Code:        http.StatusOK,
+			Operation:   openservicebroker.OperationProvisioning,
+			ServiceInstanceCond: []broker.ServiceInstanceCondition{{
+				Status: kapi.ConditionTrue,
+			}},
+			GetError:      nil,
+			InstanceID:    "instance",
+			ExpectedState: openservicebroker.LastOperationStateInProgress,
+		},
+		{
+			Name:                "lastoperation error for provisioning when service instance not found",
+			ExpectError:         true,
+			Code:                http.StatusBadRequest,
+			Operation:           openservicebroker.OperationProvisioning,
+			ServiceInstanceCond: []broker.ServiceInstanceCondition{},
+			GetError:            kerrors.NewNotFound(broker.Resource("serviceInstance"), "test"),
+			InstanceID:          "instance",
+		},
+		{
+			Name:                "lastoperation service gone for deprovisioning",
+			ExpectError:         false,
+			Code:                http.StatusGone,
+			Operation:           openservicebroker.OperationDeprovisioning,
+			ServiceInstanceCond: []broker.ServiceInstanceCondition{},
+			GetError:            kerrors.NewNotFound(broker.Resource("serviceInstance"), "test"),
+			InstanceID:          "instance",
+		},
+		{
+			Name:                "lastoperation internal service error when general error finding service instance",
+			ExpectError:         true,
+			Code:                http.StatusInternalServerError,
+			Operation:           openservicebroker.OperationProvisioning,
+			ServiceInstanceCond: []broker.ServiceInstanceCondition{},
+			GetError:            errors.New("something terribly wrong"),
+			InstanceID:          "instance",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			client := &clientset.Clientset{}
+			client.Fake = ktesting.Fake{}
+			client.Fake.AddReactor("get", "*", func(a ktesting.Action) (bool, runtime.Object, error) {
+				serviceInstance := &broker.ServiceInstance{
+					Status: broker.ServiceInstanceStatus{
+						Conditions: tc.ServiceInstanceCond,
+					},
+				}
+				return true, serviceInstance, tc.GetError
+			})
+			broker := &BrokerOperations{
+				Client: client,
+			}
+			res := broker.LastOperation(tc.InstanceID, tc.Operation)
+			if tc.ExpectError && res.Err == nil {
+				t.Fatal("Expected an err from lastoperation but got none")
+			}
+			if !tc.ExpectError && res.Err != nil {
+				t.Fatalf("did not expect an error from lastoperation : %s ", res.Err)
+			}
+			if tc.Code != res.Code {
+				t.Fatalf("expected a response code %v but got %v ", tc.Code, res.Code)
+			}
+			if res.Code == http.StatusOK {
+				loRes, ok := res.Body.(*openservicebroker.LastOperationResponse)
+				if !ok {
+					t.Fatal("expected the response body to be a LastOperationResponse")
+				}
+				if loRes.State != tc.ExpectedState {
+					t.Fatalf("expected lastoperation state to be %v but got %v ", tc.ExpectedState, loRes.State)
+				}
+			}
+		})
+	}
+}

--- a/pkg/openservicebroker/operations/provision.go
+++ b/pkg/openservicebroker/operations/provision.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/golang/glog"
@@ -11,11 +12,14 @@ import (
 )
 
 // Provision is an implementation of the service broker provision api
-func (b *BrokerOperations) Provision(instance_id string, preq *openservicebroker.ProvisionRequest) *openservicebroker.Response {
+func (b *BrokerOperations) Provision(instanceID string, preq *openservicebroker.ProvisionRequest) *openservicebroker.Response {
+	if !preq.AcceptsIncomplete {
+		return &openservicebroker.Response{Code: http.StatusUnprocessableEntity, Body: openservicebroker.ProvisionResponse{}, Err: errors.New("cannot provision service synchronously")}
+	}
 	// provision will create a new ServiceInstance resource to be processed
 	// by the controller.
 	si := brokerapi.ServiceInstance{}
-	si.Name = instance_id
+	si.Name = instanceID
 	// this credential will be returned to bind requests, in theory it is a value
 	// consumers of the service instance will need to access the instance.
 	si.Spec.Credential = "some_secret"
@@ -23,14 +27,14 @@ func (b *BrokerOperations) Provision(instance_id string, preq *openservicebroker
 
 	// Create the ServiceInstance object that represents this service instance.  The
 	// controller will see the request and progress it from there.
-	_, err := b.Client.ServiceInstances(broker.Namespace).Create(&si)
+	_, err := b.Client.Broker().ServiceInstances(broker.Namespace).Create(&si)
 	if err != nil {
 		glog.Errorf("Failed to create a service instance\n:%v\n", err)
 	}
 
 	// Use this for async provision flows.  Technically the service instance isn't provisioned
 	// until the controller sees the request, does work, and marks it ready.
-	return &openservicebroker.Response{http.StatusAccepted, openservicebroker.ProvisionResponse{Operation: openservicebroker.OperationProvisioning}, nil}
+	return &openservicebroker.Response{Code: http.StatusAccepted, Body: openservicebroker.ProvisionResponse{Operation: openservicebroker.OperationProvisioning}, Err: err}
 
 	// For synchronous flows we can just return complete.
 	//return &openservicebroker.Response{http.StatusOK, openservicebroker.ProvisionResponse{Operation: openservicebroker.OperationProvisioning}, nil}

--- a/pkg/openservicebroker/operations/provision_test.go
+++ b/pkg/openservicebroker/operations/provision_test.go
@@ -1,0 +1,71 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/openshift/open-service-broker-sdk/pkg/apis/broker"
+	clientset "github.com/openshift/open-service-broker-sdk/pkg/client/clientset_generated/internalclientset/fake"
+	"github.com/openshift/open-service-broker-sdk/pkg/openservicebroker"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestProvision(t *testing.T) {
+	cases := []struct {
+		Name        string
+		InstanceID  string
+		ExpectError bool
+		Request     *openservicebroker.ProvisionRequest
+		Code        int
+	}{
+		{
+			Name:        "test async provision success",
+			InstanceID:  "testID",
+			ExpectError: false,
+			Code:        202,
+			Request: &openservicebroker.ProvisionRequest{
+				ServiceID:         "test",
+				PlanID:            "test",
+				Parameters:        map[string]string{},
+				AcceptsIncomplete: true,
+				OrganizationID:    "org",
+				SpaceID:           "space",
+			},
+		},
+		{
+			Name:        "test sync provision fails with unprocessable entity",
+			InstanceID:  "testID",
+			ExpectError: true,
+			Code:        422,
+			Request: &openservicebroker.ProvisionRequest{
+				ServiceID:         "test",
+				PlanID:            "test",
+				Parameters:        map[string]string{},
+				AcceptsIncomplete: false,
+				OrganizationID:    "org",
+				SpaceID:           "space",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		si := &broker.ServiceInstance{
+			ObjectMeta: metav1.ObjectMeta{Namespace: broker.Namespace},
+		}
+
+		broker := &BrokerOperations{
+			Client: clientset.NewSimpleClientset(si),
+		}
+		t.Run(tc.Name, func(t *testing.T) {
+			res := broker.Provision(tc.InstanceID, tc.Request)
+			if tc.ExpectError && res.Err == nil {
+				t.Fatal("Expected an err provisioning but got none")
+			}
+			if !tc.ExpectError && res.Err != nil {
+				t.Fatalf("did not expect an error provisioning : %s ", res.Err)
+			}
+			if res.Code != tc.Code {
+				t.Fatalf("Expected a status code %v but got %v", tc.Code, res.Code)
+			}
+		})
+	}
+}

--- a/pkg/openservicebroker/operations/unbind.go
+++ b/pkg/openservicebroker/operations/unbind.go
@@ -7,8 +7,8 @@ import (
 )
 
 // Unbind is an implementation of the service broker unbind api
-func (b *BrokerOperations) Unbind(instance_id, binding_id string) *openservicebroker.Response {
+func (b *BrokerOperations) Unbind(instanceID, bindingID string) *openservicebroker.Response {
 	// in principle, unbind should alter state somewhere (e.g. invalidating the credentials
 	// associated with this binding, for brokers that provide unique credentials for each binding)
-	return &openservicebroker.Response{http.StatusOK, &openservicebroker.UnbindResponse{}, nil}
+	return &openservicebroker.Response{Code: http.StatusOK, Body: &openservicebroker.UnbindResponse{}, Err: nil}
 }

--- a/pkg/openservicebroker/operations/unbind_test.go
+++ b/pkg/openservicebroker/operations/unbind_test.go
@@ -1,0 +1,47 @@
+package operations
+
+import (
+	"net/http"
+	"testing"
+
+	clientset "github.com/openshift/open-service-broker-sdk/pkg/client/clientset_generated/internalclientset/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestUnbind(t *testing.T) {
+	cases := []struct {
+		Name        string
+		ExpectError bool
+		Code        int
+		instanceID  string
+		bindingID   string
+	}{
+		{
+			Name:        "unbinds ok",
+			ExpectError: false,
+			Code:        http.StatusOK,
+			instanceID:  "instance",
+			bindingID:   "binding",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			client := &clientset.Clientset{}
+			client.Fake = ktesting.Fake{}
+			broker := &BrokerOperations{
+				Client: client,
+			}
+			res := broker.Unbind(tc.instanceID, tc.bindingID)
+			if tc.ExpectError && res.Err == nil {
+				t.Fatal("Expected an err unbinding but got none")
+			}
+			if !tc.ExpectError && res.Err != nil {
+				t.Fatalf("did not expect an error unbinding : %s ", res.Err)
+			}
+			if tc.Code != res.Code {
+				t.Fatalf("expected a response code %v but got %v ", tc.Code, res.Code)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adding some basic unit tests for some of the operations. 
Also small refactors to help with the tests and lint.
The idea here is to show developers how they can approach testing their broker, particularly around the use of the client and fakes (something I was unaware of before this).

@bparees Interested in your thoughts on this, if you feel it is a good idea to add these kinds of tests, I will fill out the rest of the operations