### PR TITLE
Add the context field to the provision and update requests

### DIFF
--- a/pkg/openservicebroker/operations/provision.go
+++ b/pkg/openservicebroker/operations/provision.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/golang/glog"
 
-	broker "github.com/openshift/open-service-broker-sdk/pkg/apis/broker"
 	brokerapi "github.com/openshift/open-service-broker-sdk/pkg/apis/broker"
 	"github.com/openshift/open-service-broker-sdk/pkg/openservicebroker"
 )
@@ -27,7 +26,7 @@ func (b *BrokerOperations) Provision(instanceID string, preq *openservicebroker.
 
 	// Create the ServiceInstance object that represents this service instance.  The
 	// controller will see the request and progress it from there.
-	_, err := b.Client.Broker().ServiceInstances(broker.Namespace).Create(&si)
+	_, err := b.Client.Broker().ServiceInstances(preq.Context.Namespace).Create(&si)
 	if err != nil {
 		glog.Errorf("Failed to create a service instance\n:%v\n", err)
 		return &openservicebroker.Response{Code: http.StatusInternalServerError, Body: nil, Err: err}

--- a/pkg/openservicebroker/operations/provision_test.go
+++ b/pkg/openservicebroker/operations/provision_test.go
@@ -23,6 +23,10 @@ func TestProvision(t *testing.T) {
 			ExpectError: false,
 			Code:        202,
 			Request: &openservicebroker.ProvisionRequest{
+				Context: openservicebroker.KubernetesContext{
+					Platform:  "kubernetes",
+					Namespace: "test",
+				},
 				ServiceID:         "test",
 				PlanID:            "test",
 				Parameters:        map[string]string{},
@@ -37,6 +41,10 @@ func TestProvision(t *testing.T) {
 			ExpectError: true,
 			Code:        422,
 			Request: &openservicebroker.ProvisionRequest{
+				Context: openservicebroker.KubernetesContext{
+					Platform:  "kubernetes",
+					Namespace: "test",
+				},
 				ServiceID:         "test",
 				PlanID:            "test",
 				Parameters:        map[string]string{},

--- a/pkg/openservicebroker/types.go
+++ b/pkg/openservicebroker/types.go
@@ -62,8 +62,15 @@ const (
 	LastOperationStateFailed     LastOperationState = "failed"
 )
 
+// KubernetesContext is sent as part of a provision or update call to a service broker running in a kubernetes cluter.
+type KubernetesContext struct {
+	Platform  string `json:"platform"`
+	Namespace string `json:"namespace"`
+}
+
 // ProvisionRequest is sent as part of a provision api call
 type ProvisionRequest struct {
+	Context           KubernetesContext `json:"context"`
 	ServiceID         string            `json:"service_id"`
 	PlanID            string            `json:"plan_id"`
 	Parameters        map[string]string `json:"parameters,omitempty"`
@@ -81,6 +88,7 @@ type ProvisionResponse struct {
 type Operation string
 
 type UpdateRequest struct {
+	Context           KubernetesContext `json:"context"`
 	ServiceID         string            `json:"service_id"`
 	PlanID            string            `json:"plan_id,omitempty"`
 	Parameters        map[string]string `json:"parameters,omitempty"`

--- a/test/integration/provision_test.go
+++ b/test/integration/provision_test.go
@@ -26,6 +26,10 @@ func TestProvisionEndpoint(t *testing.T) {
 		{
 			Name: "it should provision ok",
 			ProvisionReq: &openservicebroker.ProvisionRequest{
+				Context: openservicebroker.KubernetesContext{
+					Platform:  "kubernetes",
+					Namespace: "test",
+				},
 				AcceptsIncomplete: true,
 				PlanID:            "thePlan",
 				OrganizationID:    "theOrg",


### PR DESCRIPTION
Adds in the context object to provision and update requests for kubernetes based service brokers. 
https://github.com/openservicebrokerapi/servicebroker/blob/v2.12/spec.md#route-2